### PR TITLE
added section-level empty-reason of ‘withheld'. Fixes #102

### DIFF
--- a/input/pagecontent/fhir-example.md
+++ b/input/pagecontent/fhir-example.md
@@ -74,7 +74,9 @@ ent Reason extension to indicate why the data is not present. This is analogous 
 
 **Example Usage:**
 
-When Patient.telecom is removed during de-identification:
+In the following example, multiple de-identification actions are applied to the Patient resource: `Patient.id` and `Patient.name` are pseudonymized, `Patient.telecom` is removed and marked as masked using the Data Absent Reason extension, and `Patient.birthDate` is generalized to year-only precision to reduce re-identification risk while preserving analytical value.
+
+Example Patient resource after these de-identification actions:
 
 ```json
 {
@@ -128,27 +130,6 @@ When a section is intentionally omitted to satisfy minimum necessary disclosure,
 
 ```json
 {
-  "resourceType": "Composition",
-  "status": "final",
-  "type": {
-    "coding": [
-      {
-        "system": "http://loinc.org",
-        "code": "34133-9",
-        "display": "Summary of episode note"
-      }
-    ]
-  },
-  "subject": {
-    "reference": "Patient/pseudo-a1b2c3d4"
-  },
-  "date": "2026-03-12T10:00:00Z",
-  "author": [
-    {
-      "reference": "Organization/example"
-    }
-  ],
-  "title": "De-identified clinical summary",
   "section": [
     {
       "title": "Social History",

--- a/input/pagecontent/fhir-example.md
+++ b/input/pagecontent/fhir-example.md
@@ -74,7 +74,7 @@ ent Reason extension to indicate why the data is not present. This is analogous 
 
 **Example Usage:**
 
-When Patient.name is removed during de-identification:
+When Patient.telecom is removed during de-identification:
 
 ```json
 {
@@ -89,7 +89,13 @@ When Patient.name is removed during de-identification:
       }
     ]
   },
-  "_name": [
+  "name": [
+    {
+      "family": "StudySubject-12345",
+      "given": ["Pseudo"]
+    }
+  ],
+  "_telecom": [
     {
       "extension": [
         {
@@ -101,6 +107,68 @@ When Patient.name is removed during de-identification:
   ],
   "gender": "female",
   "birthDate": "1985"
+}
+```
+
+### Section-level withholding for data minimization (List Empty Reason)
+
+For section-level suppression (for example, withholding an entire document section during de-identification), use `Composition.section.emptyReason` with the List Empty Reason value set, rather than element-level Data Absent Reason.
+
+This is a different mechanism and terminology binding than Data Absent Reason:
+
+| Context | Element | Terminology | Recommended code for de-identification minimization |
+| ------- | ------- | ----------- | ---------------------------------------------------- |
+| Element-level missing data | Extension `data-absent-reason` | `http://hl7.org/fhir/ValueSet/data-absent-reason` | `masked` |
+| Section-level withheld content | `Composition.section.emptyReason` | `http://hl7.org/fhir/ValueSet/list-empty-reason` | `withheld` |
+{:.grid}
+
+When a section is intentionally omitted to satisfy minimum necessary disclosure, set `emptyReason` to `withheld`.
+
+**Example: Composition section withheld for data minimization**
+
+```json
+{
+  "resourceType": "Composition",
+  "status": "final",
+  "type": {
+    "coding": [
+      {
+        "system": "http://loinc.org",
+        "code": "34133-9",
+        "display": "Summary of episode note"
+      }
+    ]
+  },
+  "subject": {
+    "reference": "Patient/pseudo-a1b2c3d4"
+  },
+  "date": "2026-03-12T10:00:00Z",
+  "author": [
+    {
+      "reference": "Organization/example"
+    }
+  ],
+  "title": "De-identified clinical summary",
+  "section": [
+    {
+      "title": "Social History",
+      "text": {
+        "status": "generated",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Section content withheld for data minimization.</div>"
+      },
+      "entry": [],
+      "emptyReason": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/list-empty-reason",
+            "code": "withheld",
+            "display": "Withheld"
+          }
+        ],
+        "text": "Withheld for de-identification and data minimization"
+      }
+    }
+  ]
 }
 ```
 
@@ -209,14 +277,10 @@ FHIR resources should be labeled with appropriate security tags to indicate thei
       "value": "STUDY-PSEUDO-12345"
     }
   ],
-  "_name": [
+  "name": [
     {
-      "extension": [
-        {
-          "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-          "valueCode": "masked"
-        }
-      ]
+      "family": "StudySubject-a1b2c3d4",
+      "given": ["Pseudo"]
     }
   ],
   "_telecom": [
@@ -270,14 +334,10 @@ FHIR resources should be labeled with appropriate security tags to indicate thei
       "value": "STUDY-PSEUDO-12345"
     }
   ],
-  "_name": [
+  "name": [
     {
-      "extension": [
-        {
-          "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-          "valueCode": "masked"
-        }
-      ]
+      "family": "StudySubject-a1b2c3d4",
+      "given": ["Pseudo"]
     }
   ],
   "_telecom": [


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 

Please make sure that the pull request is limited to one Issue and keep it as small as possible. You can open multiple pull request instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #102 

## 📑 Description
On the FHIR example page, there is no reference to a section-level empty-reason of ‘withheld’ to support data minimization at the section level. Since this is sourced from a different value set, it should probably be a separate sub-section like this that instructs data de-identified for data minimization at the section level should be withheld.

Also, In the example of a pseudonymized patient, we had discussed that the patient name can not be empty – a pseudonym may be used. A different demographic element would be better (e.g. telecom).


Added a separate section ### Section-level withholding for data minimization (List Empty Reason) and also kept the patient name element with a pseudonym.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed
- [x] I have selected a committee co-chair to review the PR

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->