### PR TITLE
updated '_telecom' to 'telcom' in the fhir-example.

### DIFF
--- a/input/pagecontent/fhir-example.md
+++ b/input/pagecontent/fhir-example.md
@@ -97,7 +97,7 @@ Example Patient resource after these de-identification actions:
       "given": ["Pseudo"]
     }
   ],
-  "_telecom": [
+  "telecom": [
     {
       "extension": [
         {
@@ -264,7 +264,7 @@ FHIR resources should be labeled with appropriate security tags to indicate thei
       "given": ["Pseudo"]
     }
   ],
-  "_telecom": [
+  "telecom": [
     {
       "extension": [
         {
@@ -321,7 +321,7 @@ FHIR resources should be labeled with appropriate security tags to indicate thei
       "given": ["Pseudo"]
     }
   ],
-  "_telecom": [
+  "telecom": [
     {
       "extension": [
         {


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 

Please make sure that the pull request is limited to one Issue and keep it as small as possible. You can open multiple pull request instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #106 

## 📑 Description
In the FHIR example, "_telecom" is used in the example json of a de-identified FHIR patient resource, see below:
  "_telecom": [ { "extension": [ { "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason", "valueCode": "masked" } ] } ]

However, it's not correct, telecom element is not primitive type, so underscore mechanism can not be used. The correct method of adding the extension is as below:
 "telecom": [ { "extension": [ { "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason", "valueCode": "masked" } ] } ]

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed
- [x] I have selected a committee co-chair to review the PR

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->